### PR TITLE
Resolved crash in iPad #29: when tapping share button

### DIFF
--- a/FileExplorer/FileExplorer/ActionsViewController.swift
+++ b/FileExplorer/FileExplorer/ActionsViewController.swift
@@ -33,7 +33,7 @@ protocol ActionsViewControllerDelegate: class {
 final class ActionsViewController: UIViewController {
     weak var delegate: ActionsViewControllerDelegate?
 
-    let toolbar = UIToolbar()
+    private let toolbar = UIToolbar()
     private let contentViewController: UIViewController
 
     init(contentViewController: UIViewController) {
@@ -77,5 +77,11 @@ final class ActionsViewController: UIViewController {
     @objc
     private func handleTrashButtonTap() {
         delegate?.actionsViewControllerDidRequestRemoval(self)
+    }
+    
+    //MARK: public access
+    
+    func shareButton() -> UIBarButtonItem? {
+        return toolbar.items?[0]
     }
 }

--- a/FileExplorer/FileExplorer/ActionsViewController.swift
+++ b/FileExplorer/FileExplorer/ActionsViewController.swift
@@ -33,7 +33,7 @@ protocol ActionsViewControllerDelegate: class {
 final class ActionsViewController: UIViewController {
     weak var delegate: ActionsViewControllerDelegate?
 
-    private let toolbar = UIToolbar()
+    let toolbar = UIToolbar()
     private let contentViewController: UIViewController
 
     init(contentViewController: UIViewController) {

--- a/FileExplorer/FileExplorer/FileItemPresentationCoordinator.swift
+++ b/FileExplorer/FileExplorer/FileItemPresentationCoordinator.swift
@@ -81,6 +81,7 @@ extension FileItemPresentationCoordinator: ActionsViewControllerDelegate {
     func actionsViewControllerDidRequestShare(_ controller: ActionsViewController) {
         let activityItem = UIActivityItemProvider(placeholderItem: item.url)
         let activityViewController = UIActivityViewController(activityItems: [activityItem], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.barButtonItem = controller.toolbar.items?[0]
         navigationController?.present(activityViewController, animated: true, completion: nil)
     }
 

--- a/FileExplorer/FileExplorer/FileItemPresentationCoordinator.swift
+++ b/FileExplorer/FileExplorer/FileItemPresentationCoordinator.swift
@@ -81,7 +81,7 @@ extension FileItemPresentationCoordinator: ActionsViewControllerDelegate {
     func actionsViewControllerDidRequestShare(_ controller: ActionsViewController) {
         let activityItem = UIActivityItemProvider(placeholderItem: item.url)
         let activityViewController = UIActivityViewController(activityItems: [activityItem], applicationActivities: nil)
-        activityViewController.popoverPresentationController?.barButtonItem = controller.toolbar.items?[0]
+        activityViewController.popoverPresentationController?.barButtonItem = controller.shareButton()
         navigationController?.present(activityViewController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Resolved: #29
When we run the application in iPad it crash on tapping share button.  This is because source rect for popoverViewController is nil, when presenting UIActivityViewController.  
