### PR TITLE
Selectable file formats

### DIFF
--- a/FileExplorer/FileExplorer/Configuration.swift
+++ b/FileExplorer/FileExplorer/Configuration.swift
@@ -41,11 +41,26 @@ struct ActionsConfiguration {
 struct FilteringConfiguration {
     var fileFilters: [Filter]
     var ignoredFileFilters: [Filter]
+    var selectableFileExtensions: [String]
 }
 
 extension FilteringConfiguration {
     init() {
-        self.init(fileFilters: [Filter](), ignoredFileFilters: [Filter]())
+        self.init(fileFilters: [Filter](), ignoredFileFilters: [Filter](), selectableFileExtensions: [String]())
+    }
+    
+    func isSelectableFileExtension(fileItem: Item<Any>) -> Bool{
+        var isSelectable = true
+        if selectableFileExtensions.count > 0 {
+            isSelectable = false
+            for selectableExtension in selectableFileExtensions {
+                if fileItem.extension == selectableExtension {
+                    isSelectable = true
+                    break
+                }
+            }
+        }
+        return isSelectable
     }
 }
 

--- a/FileExplorer/FileExplorer/DirectoryContentViewModel.swift
+++ b/FileExplorer/FileExplorer/DirectoryContentViewModel.swift
@@ -142,6 +142,12 @@ final class DirectoryContentViewModel {
                 return false
             } else if item.type == ItemType.file && !configuration.actionsConfiguration.canChooseFiles {
                 return false
+            } else if item.type == ItemType.file{
+                if configuration.filteringConfiguration.isSelectableFileExtension(fileItem: item) {
+                    return true && enabled
+                    } else {
+                    return false
+                }
             } else {
                 return true && enabled
             }

--- a/FileExplorer/FileExplorer/FileExplorerViewController.swift
+++ b/FileExplorer/FileExplorer/FileExplorerViewController.swift
@@ -73,6 +73,11 @@ public final class FileExplorerViewController: UIViewController {
     /// Results of multiple filters are combined and all of them aren't displayed by file explorer view controller. All files passing filters from `fileFilters` property are displayed if there are no filters in `ignoredFileFilters` array.
     public var ignoredFileFilters = [Filter]()
 
+    /// Filters that determine which files extensions can be selected by file explorer view controller.
+    ///
+    /// A list of String containing all the selectable file folmats. All files are displayed if `fileFilters` array is empty.
+    public var selectableFileExtensions = [String]()
+    
     /// The file explorer's delegate object.
     public weak var delegate: FileExplorerViewControllerDelegate?
 
@@ -118,7 +123,7 @@ public final class FileExplorerViewController: UIViewController {
                                                         canChooseFiles: canChooseFiles,
                                                         canChooseDirectories: canChooseDirectories,
                                                         allowsMultipleSelection: allowsMultipleSelection)
-        let filteringConfiguration = FilteringConfiguration(fileFilters: fileFilters, ignoredFileFilters: ignoredFileFilters)
+        let filteringConfiguration = FilteringConfiguration(fileFilters: fileFilters, ignoredFileFilters: ignoredFileFilters, selectableFileExtensions:selectableFileExtensions)
         let configuration = Configuration(actionsConfiguration: actionsConfiguration, filteringConfiguration: filteringConfiguration)
 
         if let item = Item<Any>.at(initialDirectoryURL, isDirectory: true) {

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ public func fileExplorerViewController(_ controller: FileExplorerViewController,
 }
 ```
 
+### Deciding Which Files Extensions User can Choose
+
+Configure `FileExplorer` so that user is allowed to choose files of only specific file extensions:
+
+```Swift
+let fileExplorer = FileExplorerViewController()
+fileExplorer.canChooseFiles = true //specify whether user is allowed to choose files
+fileExplorer.canChooseDirectories = false //specify whether user is allowed to choose directories
+
+List the file extensions that can be choosen
+fileExplorer.selectableFileExtensions = ["png", "mp3"]
+
+fileExplorer.delegate = self
+
+self.present(fileExplorer, animated: true, completion: nil)
+```
+
+If no file extensions are specified as selectableFileExtensions, all file types are enabled by default.
+
 ### Deciding Whether User Can Delete Files and/or Directories
 
 Configure `FileExplorer` so that user is allowed to remove files and/or directories:


### PR DESCRIPTION
Added the feature to allow users to enable some file extensions so that user can select only specific file types.

Note, this feature is different from the existing filters in the sense that it shows all the file types and simply disable selection on some.

README file is also updated with the instructions on how to use this feature.